### PR TITLE
update pdfium version to 2.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "wasm-pack": "^0.12.1"
   },
   "dependencies": {
-    "@embedpdf/engines": "^1.3.13",
-    "@embedpdf/pdfium": "^1.3.13",
+    "@embedpdf/engines": "^2.14.0",
+    "@embedpdf/pdfium": "^2.14.0",
     "dotenv": "^17.2.3",
     "esbuild-plugin-inline-worker": "^0.1.1",
     "fflate": "^0.8.2",


### PR DESCRIPTION
fixes #7

The origin of the problem is that `@embedpdf/pdfium` is missing the `invoke_vi` function for interface WASM. This is solved in recent versions.